### PR TITLE
생성자 선택 문제

### DIFF
--- a/eatgo-api/src/main/java/kr/co/fastcampus/eatgo/interfaces/RestaurantController.java
+++ b/eatgo-api/src/main/java/kr/co/fastcampus/eatgo/interfaces/RestaurantController.java
@@ -36,12 +36,12 @@ public class RestaurantController {
         String name = resource.getName();
         String address = resource.getAddress();
 
-//        Restaurant restaurant = new Restaurant(name, address);
-//        restaurantService.addRestaurant(restaurant);
+        Restaurant restaurant = new Restaurant(name, address);
+        restaurant = restaurantService.addRestaurant(restaurant);
 
-        Restaurant restaurant = restaurantService.addRestaurant(
-                new Restaurant(name, address)
-        );
+//        Restaurant restaurant = restaurantService.addRestaurant(
+//                new Restaurant(name, address)
+//        );
 
 //        Restaurant restaurant = restaurantService.addRestaurant(
 //                Restaurant.builder()


### PR DESCRIPTION
생성자 [Restaurant(name, address)](https://github.com/gimandbob/eatgo/blob/2029a54fc2aafb6bcf86a486ea333fc1534b2a40/eatgo-api/src/main/java/kr/co/fastcampus/eatgo/domain/Restaurant.java#L31)는 `id`를 `null` 값으로 객체를 생성하기 때문에
반환되는 [location 값](https://github.com/gimandbob/eatgo/blob/2029a54fc2aafb6bcf86a486ea333fc1534b2a40/eatgo-api/src/main/java/kr/co/fastcampus/eatgo/interfaces/RestaurantController.java#L53)이 `/restaurants/1234` 가 아닌 `/restaurants/null` 입니다.

따라서 [테스트](https://github.com/gimandbob/eatgo/blob/2029a54fc2aafb6bcf86a486ea333fc1534b2a40/eatgo-api/src/test/java/kr/co/fastcampus/eatgo/interfaces/RestaurantControllerTest.java#L117)를 통과하기 위해서는
`addRestaurant(any())`가 반환하는 [Restaurant 객체](https://github.com/gimandbob/eatgo/blob/2029a54fc2aafb6bcf86a486ea333fc1534b2a40/eatgo-api/src/test/java/kr/co/fastcampus/eatgo/interfaces/RestaurantControllerTest.java#L105)를 다시 변수에 담아야 합니다.